### PR TITLE
chore: update husky hooks for v10 compatibility

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 # Run format check and clippy
 cargo fmt --all -- --check
 cargo clippy --all-targets --all-features -- -D warnings

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 # Run all checks (format, clippy, and tests)
 ./scripts/check.sh


### PR DESCRIPTION
chore: Update Husky Hooks for v10 Compatibility

## Overview
This PR updates Husky git hooks to be compatible with the upcoming Husky v10 release by removing deprecated code.

## Changes
- Removed deprecated shebang and import lines from pre-commit hook
- Removed deprecated shebang and import lines from pre-push hook
- Hooks functionality verified with test commits

## What This Fixes
This fixes the deprecation warning that appeared during git push operations:

```
husky - DEPRECATED

Please remove the following two lines from .husky/pre-push:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
```

## Testing
All hooks have been tested to ensure they continue to function correctly.
