### PR TITLE
docs: move documentation to GitHub Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ AureaCore is part of SpiralHouse's suite of open-source tools dedicated to enhan
 
 ## Documentation
 
-Detailed documentation can be found in the `docs` directory:
+Detailed documentation can be found in the [GitHub Wiki](https://github.com/spiralhouse/aureacore/wiki):
 
-* [Architecture Decisions](docs/adr) - Architectural decision records
-* System Overview (coming soon)
-* Integration Guide (coming soon)
-* User Guide (coming soon)
-* Operations Guide (coming soon)
+* [Getting Started](https://github.com/spiralhouse/aureacore/wiki/Getting-Started) - Installation and quick start guides
+* [Architecture](https://github.com/spiralhouse/aureacore/wiki/Architecture) - System architecture and design
+* [Guides](https://github.com/spiralhouse/aureacore/wiki/Guides) - How-to guides for common tasks
+* [API Documentation](https://github.com/spiralhouse/aureacore/wiki/API-Documentation) - API reference
+* [Architecture Decision Records](https://github.com/spiralhouse/aureacore/wiki/Architecture-Decision-Records) - Records of architecture decisions
+* [Contributing](https://github.com/spiralhouse/aureacore/wiki/Contributing) - Guidelines for contributing to the project
 
 ## Getting Started
 
@@ -81,7 +82,7 @@ This project is currently in the architectural design phase. Implementation will
 
 ## Contributing
 
-Contributions are welcome! Please read our [Contributing Guidelines](CONTRIBUTING.md) before submitting a pull request.
+Contributions are welcome! Please read our [Contributing Guidelines](https://github.com/spiralhouse/aureacore/wiki/Contributing) before submitting a pull request.
 
 ### Development Setup
 


### PR DESCRIPTION
docs: Move Documentation to GitHub Wiki

## Overview
This PR updates the README to point to the GitHub Wiki instead of the `docs` directory.

## Changes
- Updated Documentation section to link to GitHub Wiki pages
- Updated Contributing section to link to Wiki Contributing page
- Removed references to docs directory in favor of Wiki links

## Context
Moving documentation to GitHub Wiki provides several benefits:
- Better organization with sidebar navigation
- Easier to browse and search
- Improved rendering of markdown and diagrams
- Separation of code and documentation
- Ability to update documentation without code changes

## Next Steps
After this PR is merged:
1. Enable GitHub Wiki for the repository
2. Upload the prepared wiki pages from the ZIP file (`/Users/jburbridge/Projects/aureacore-wiki.zip`)
3. Delete the outdated documentation from the `docs` directory (in a separate PR)
