### PR TITLE
chore: setup semantic versioning with cargo-release and github actions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,22 @@
+[package]
+# The current version will come from Cargo.toml
+
+[workspace.metadata.release]
+# Configuration for cargo-release
+pre-release-replacements = [
+    { file = "README.md", search = "spiralhouse/aureacore/releases/tag/v[0-9\\.]+", replace = "spiralhouse/aureacore/releases/tag/v{{version}}" },
+    { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
+    { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
+]
+# Configure the tag format
+tag-prefix = "v"
+# GitHub release configuration
+release = true
+# Don't publish to crates.io until you're ready
+publish = false
+# Use conventional commits to determine version bump
+# Update version based on conventional commit types:
+# - fix: patch bump
+# - feat: minor bump
+# - BREAKING CHANGE: major bump
+conventional-commits = true

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,13 +1,10 @@
 [package]
 # The current version will come from Cargo.toml
 
+[build]
+# Build configuration
+
 [cargo-release]
-# Configuration for cargo-release
-pre-release-replacements = [
-    { file = "README.md", search = "spiralhouse/aureacore/releases/tag/v[0-9\\.]+", replace = "spiralhouse/aureacore/releases/tag/v{{version}}" },
-    { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
-    { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
-]
 # Configure the tag format
 tag-prefix = "v"
 # GitHub release configuration

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [package]
 # The current version will come from Cargo.toml
 
-[workspace.metadata.release]
+[cargo-release]
 # Configuration for cargo-release
 pre-release-replacements = [
     { file = "README.md", search = "spiralhouse/aureacore/releases/tag/v[0-9\\.]+", replace = "spiralhouse/aureacore/releases/tag/v{{version}}" },

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -104,3 +104,9 @@ jobs:
           files: coverage.lcov
           fail_ci_if_error: true
           verbose: true 
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+
+jobs:
+  check-release:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      next_version: ${{ steps.check.outputs.next_version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          
+      - name: Install cargo-conventional-commits
+        run: cargo install cargo-conventional-commits
+      
+      - name: Check if release is needed
+        id: check
+        run: |
+          NEXT_VERSION=$(cargo conventional-commits --version-from-cargo-toml --unreleased-version)
+          CURRENT_VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
+          
+          if [ "$NEXT_VERSION" != "$CURRENT_VERSION" ]; then
+            echo "should_release=true" >> $GITHUB_OUTPUT
+            echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "should_release=false" >> $GITHUB_OUTPUT
+          fi
+
+  release:
+    needs: check-release
+    if: ${{ needs.check-release.outputs.should_release == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set up Git user
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+      
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          
+      - name: Install cargo-release
+        run: cargo install cargo-release
+      
+      - name: Generate CHANGELOG
+        run: |
+          cargo install cargo-conventional-commits
+          cargo conventional-commits --update-changelog
+      
+      - name: Prepare release
+        run: |
+          VERSION=${{ needs.check-release.outputs.next_version }}
+          echo "Processing release for version $VERSION"
+          
+          # Determine version bump level
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            if [[ $(git log --format=%B -n 500 | grep -c "BREAKING CHANGE:") -gt 0 ]]; then
+              LEVEL="major"
+            elif [[ $(git log --format=%B -n 500 | grep -c "^feat") -gt 0 ]]; then
+              LEVEL="minor"
+            else
+              LEVEL="patch"
+            fi
+            
+            echo "Releasing $LEVEL version: $VERSION"
+            cargo release $LEVEL --no-dev-version --no-confirm --execute
+          fi
+      
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ needs.check-release.outputs.next_version }}
+          name: Release v${{ needs.check-release.outputs.next_version }}
+          body_path: CHANGELOG.md
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to AureaCore will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] - ReleaseDate
+
+### Added
+- Initial project setup
+- Core service registry implementation
+- Service Registry Foundation milestone completed
+- Schema validation foundation (in progress)
+
+### Changed
+- Updated documentation and README
+- Removed MongoDB dependency
+
+### Fixed
+- N/A 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,6 @@ license = "Apache-2.0 WITH Commons-Clause"
 members = ["core", "api", "plugins"]
 
 [workspace.metadata.release]
-# Configuration for cargo-release
-pre-release-replacements = [
-    { file = "README.md", search = "spiralhouse/aureacore/releases/tag/v[0-9\\.]+", replace = "spiralhouse/aureacore/releases/tag/v{{version}}" },
-    { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
-    { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
-]
 # Configure the tag format
 tag-prefix = "v"
 # GitHub release configuration

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,20 @@ license = "Apache-2.0 WITH Commons-Clause"
 [workspace]
 members = ["core", "api", "plugins"]
 
+[workspace.metadata.release]
+# Configuration for cargo-release
+pre-release-replacements = [
+    { file = "README.md", search = "spiralhouse/aureacore/releases/tag/v[0-9\\.]+", replace = "spiralhouse/aureacore/releases/tag/v{{version}}" },
+    { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
+    { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
+]
+# Configure the tag format
+tag-prefix = "v"
+# GitHub release configuration
+release = true
+publish = false
+conventional-commits = true
+
 [workspace.dependencies]
 # Web Framework
 axum = { version = "0.7", features = ["macros"] }

--- a/README.md
+++ b/README.md
@@ -190,14 +190,18 @@ This project follows [Conventional Commits](https://www.conventionalcommits.org/
 ```
 
 Types include:
-* `feat`: A new feature
-* `fix`: A bug fix
+* `feat`: A new feature (triggers minor version bump)
+* `fix`: A bug fix (triggers patch version bump)
 * `docs`: Documentation changes
 * `style`: Code style changes (formatting, etc)
 * `refactor`: Code changes that neither fix bugs nor add features
 * `perf`: Performance improvements
 * `test`: Adding or updating tests
 * `chore`: Routine tasks, maintenance, etc.
+
+Breaking changes indicated with `BREAKING CHANGE:` in the footer or `!` after the type (e.g., `feat!:`) will trigger major version bumps.
+
+For more information on the release process, see [Release Process](docs/RELEASE_PROCESS.md).
 
 ## License
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,106 +1,14 @@
 # Release Process
 
-AureaCore follows [Semantic Versioning](https://semver.org/) and uses automated release processes based on [Conventional Commits](https://www.conventionalcommits.org/).
+The release process documentation for AureaCore is maintained in the project's GitHub Wiki.
 
-## Automated Releases
+Please refer to the [Release Process](https://github.com/spiralhouse/aureacore/wiki/Release-Process) page in the wiki for complete information about:
 
-Releases are automatically created when commits are merged into the `main` branch. The version number is determined based on the conventional commit messages:
+- Automated semantic versioning
+- Manual release procedures
+- Commit message guidelines
+- Version numbering conventions
 
-- `fix:` commits trigger a PATCH release (e.g., 1.0.0 → 1.0.1)
-- `feat:` commits trigger a MINOR release (e.g., 1.0.0 → 1.1.0)
-- Commits with `BREAKING CHANGE:` in the body trigger a MAJOR release (e.g., 1.0.0 → 2.0.0)
+This allows us to maintain a single source of truth for project documentation while ensuring all contributors have access to the latest information.
 
-The GitHub Actions workflow handles:
-1. Checking if a new release is needed
-2. Updating the changelog
-3. Incrementing the version number
-4. Creating a git tag
-5. Publishing a GitHub Release
-
-## Manual Release Process
-
-In some cases, you may need to create a release manually. Follow these steps:
-
-### Prerequisites
-
-Install the required tools:
-
-```bash
-npm run install-release-tools
-```
-
-or directly:
-
-```bash
-cargo install cargo-release cargo-conventional-commits
-```
-
-### Preparing for Release
-
-1. Make sure all changes are committed using conventional commits format
-2. Ensure the CHANGELOG.md is up to date
-
-### Creating a Release
-
-Run one of the following commands depending on the type of release:
-
-```bash
-# For a patch release (bug fixes)
-cargo release patch --no-dev-version --execute
-
-# For a minor release (new features)
-cargo release minor --no-dev-version --execute
-
-# For a major release (breaking changes)
-cargo release major --no-dev-version --execute
-```
-
-This will:
-- Update version in Cargo.toml
-- Update CHANGELOG.md
-- Create a git commit with the version changes
-- Create a git tag
-- Push the changes and tag to GitHub
-
-### Post-Release
-
-After a release, a GitHub Action workflow will automatically create a GitHub Release with the changelog contents.
-
-## Commit Message Guidelines
-
-For the automated versioning to work correctly, all commits should follow the Conventional Commits format:
-
-```
-<type>[optional scope]: <description>
-
-[optional body]
-
-[optional footer(s)]
-```
-
-Common types include:
-- `feat`: A new feature (triggers MINOR version bump)
-- `fix`: A bug fix (triggers PATCH version bump)
-- `docs`: Documentation changes
-- `style`: Code style changes (formatting, etc)
-- `refactor`: Code changes that neither fix bugs nor add features
-- `test`: Adding or updating tests
-- `chore`: Routine tasks, maintenance, etc.
-
-Breaking changes must be indicated in the footer with `BREAKING CHANGE:` or in the type with an exclamation mark (`feat!:`).
-
-### Examples
-
-```
-feat: add service registry validation
-
-fix: prevent registry corruption when services are deleted
-
-docs: update README with new installation instructions
-
-feat!: remove deprecated API endpoint
-
-fix: resolve service lookup issue
-
-BREAKING CHANGE: service lookup now requires authentication
-``` 
+> **Note**: If you're making changes to the release process, please update the wiki documentation rather than this file. 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,0 +1,106 @@
+# Release Process
+
+AureaCore follows [Semantic Versioning](https://semver.org/) and uses automated release processes based on [Conventional Commits](https://www.conventionalcommits.org/).
+
+## Automated Releases
+
+Releases are automatically created when commits are merged into the `main` branch. The version number is determined based on the conventional commit messages:
+
+- `fix:` commits trigger a PATCH release (e.g., 1.0.0 → 1.0.1)
+- `feat:` commits trigger a MINOR release (e.g., 1.0.0 → 1.1.0)
+- Commits with `BREAKING CHANGE:` in the body trigger a MAJOR release (e.g., 1.0.0 → 2.0.0)
+
+The GitHub Actions workflow handles:
+1. Checking if a new release is needed
+2. Updating the changelog
+3. Incrementing the version number
+4. Creating a git tag
+5. Publishing a GitHub Release
+
+## Manual Release Process
+
+In some cases, you may need to create a release manually. Follow these steps:
+
+### Prerequisites
+
+Install the required tools:
+
+```bash
+npm run install-release-tools
+```
+
+or directly:
+
+```bash
+cargo install cargo-release cargo-conventional-commits
+```
+
+### Preparing for Release
+
+1. Make sure all changes are committed using conventional commits format
+2. Ensure the CHANGELOG.md is up to date
+
+### Creating a Release
+
+Run one of the following commands depending on the type of release:
+
+```bash
+# For a patch release (bug fixes)
+cargo release patch --no-dev-version --execute
+
+# For a minor release (new features)
+cargo release minor --no-dev-version --execute
+
+# For a major release (breaking changes)
+cargo release major --no-dev-version --execute
+```
+
+This will:
+- Update version in Cargo.toml
+- Update CHANGELOG.md
+- Create a git commit with the version changes
+- Create a git tag
+- Push the changes and tag to GitHub
+
+### Post-Release
+
+After a release, a GitHub Action workflow will automatically create a GitHub Release with the changelog contents.
+
+## Commit Message Guidelines
+
+For the automated versioning to work correctly, all commits should follow the Conventional Commits format:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Common types include:
+- `feat`: A new feature (triggers MINOR version bump)
+- `fix`: A bug fix (triggers PATCH version bump)
+- `docs`: Documentation changes
+- `style`: Code style changes (formatting, etc)
+- `refactor`: Code changes that neither fix bugs nor add features
+- `test`: Adding or updating tests
+- `chore`: Routine tasks, maintenance, etc.
+
+Breaking changes must be indicated in the footer with `BREAKING CHANGE:` or in the type with an exclamation mark (`feat!:`).
+
+### Examples
+
+```
+feat: add service registry validation
+
+fix: prevent registry corruption when services are deleted
+
+docs: update README with new installation instructions
+
+feat!: remove deprecated API endpoint
+
+fix: resolve service lookup issue
+
+BREAKING CHANGE: service lookup now requires authentication
+``` 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "prepare": "husky",
-    "check": "./scripts/check.sh"
+    "check": "./scripts/check.sh",
+    "install-release-tools": "cargo install cargo-release cargo-conventional-commits"
   },
   "devDependencies": {
     "husky": "^9.0.11"


### PR DESCRIPTION
This PR sets up semantic versioning for AureaCore using cargo-release and GitHub Actions.

## Changes
- Added `.cargo/config.toml` with cargo-release configuration
- Added semantic versioning configuration to Cargo.toml
- Created a GitHub Actions workflow (`.github/workflows/release.yml`) to automate releases
- Added a CHANGELOG.md file to track changes between versions
- Created documentation on the release process in `docs/RELEASE_PROCESS.md`
- Updated the README.md with more detailed commit guidelines

## How It Works
- Commits following conventional commit format will automatically trigger version bumps
- `fix:` commits trigger patch releases (0.0.x)
- `feat:` commits trigger minor releases (0.x.0)
- `BREAKING CHANGE:` in commit body triggers major releases (x.0.0)
- GitHub Actions will create releases and tags automatically when changes are merged to main

## Manual Release
For manual releases, developers can:
1. Install required tools: `npm run install-release-tools`
2. Run appropriate command for release type:
   ```
   cargo release patch|minor|major --no-dev-version --execute
   ```

This setup ensures we maintain proper versioning based on semver standards and automatically generates a changelog for each release.