### PR TITLE
fix: update release workflow to fix installation and deprecated commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,15 @@ jobs:
           fetch-depth: 0
       
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          components: rustfmt, clippy
+          
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
           
       - name: Install cargo-conventional-commits
-        run: cargo install cargo-conventional-commits
+        run: cargo install --locked cargo-conventional-commits
       
       - name: Check if release is needed
         id: check
@@ -37,10 +38,10 @@ jobs:
           CURRENT_VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
           
           if [ "$NEXT_VERSION" != "$CURRENT_VERSION" ]; then
-            echo "should_release=true" >> $GITHUB_OUTPUT
-            echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "next_version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
           else
-            echo "should_release=false" >> $GITHUB_OUTPUT
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
           fi
 
   release:
@@ -59,18 +60,19 @@ jobs:
           git config --global user.email "actions@github.com"
       
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          components: rustfmt, clippy
+          
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
           
       - name: Install cargo-release
-        run: cargo install cargo-release
+        run: cargo install --locked cargo-release
       
       - name: Generate CHANGELOG
         run: |
-          cargo install cargo-conventional-commits
+          cargo install --locked cargo-conventional-commits
           cargo conventional-commits --update-changelog
       
       - name: Prepare release


### PR DESCRIPTION
This PR fixes the release workflow that's failing after merging the semantic versioning PR.

## Changes

1. **Fixed installation issues:**
   - Added `--locked` flag to cargo install commands to ensure compatibility
   - Added dependency caching to speed up workflow run time

2. **Updated deprecated GitHub Actions commands:**
   - Updated `echo "key=value" >> $GITHUB_OUTPUT"` to use quoted variables
   - Replaced deprecated `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@stable`
   - Added necessary components to the Rust toolchain setup

3. **Added caching:**
   - Added `Swatinem/rust-cache@v2` for faster dependency resolution

These changes should fix the failing release workflow and address the warnings about deprecated commands.

Fixes the error seen in the release workflow: https://github.com/spiralhouse/aureacore/actions/runs/14179210513/job/39721201959