### PR TITLE
feat(schema): implement service schema validation

### DIFF
--- a/.act/actual-release-test.yml
+++ b/.act/actual-release-test.yml
@@ -1,0 +1,73 @@
+name: Release Test (Actual)
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "CHANGELOG.md"
+      - "Cargo.toml"
+      - "Cargo.lock"
+
+jobs:
+  check-release:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.conventional-commits-release.outputs.release }}
+      next_version: ${{ steps.conventional-commits-release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust
+        run: |
+          echo "Setting up Rust toolchain"
+          echo "This is a mock for testing with act"
+
+      - name: Check conventional commits for release
+        id: conventional-commits-release
+        run: |
+          echo "Checking for conventional commits"
+          echo "release=true" >> "$GITHUB_OUTPUT"
+          echo "version=0.1.1" >> "$GITHUB_OUTPUT"
+          echo "Would normally use TriPSs/conventional-changelog-action@v3"
+
+  release:
+    needs: check-release
+    if: ${{ needs.check-release.outputs.should_release == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Git user
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+
+      - name: Set up Rust
+        run: |
+          echo "Setting up Rust toolchain"
+          echo "This is a mock for testing with act"
+
+      - name: Install cargo-release
+        run: |
+          echo "Would install cargo-release"
+          echo "This is a mock for testing with act"
+
+      - name: Update CHANGELOG and version
+        id: changelog
+        run: |
+          echo "Updating CHANGELOG and version"
+          echo "version=0.1.1" >> "$GITHUB_OUTPUT"
+          echo "clean_changelog=## 0.1.1 (2025-03-31)\n\n### Features\n\n* Add semantic versioning support\n\n### Bug Fixes\n\n* Fix workflow issues" >> "$GITHUB_OUTPUT"
+          echo "Would normally use TriPSs/conventional-changelog-action@v3"
+
+      - name: Mock GitHub Release creation
+        run: |
+          echo "Creating GitHub Release v${{ steps.changelog.outputs.version }}"
+          echo "Release body would be:"
+          echo "${{ steps.changelog.outputs.clean_changelog }}"
+          echo "Would normally use softprops/action-gh-release@v1"

--- a/.act/release-test.yml
+++ b/.act/release-test.yml
@@ -1,0 +1,40 @@
+name: Release Test
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  check-release:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Mock version detection
+        id: check
+        run: |
+          echo "Current version: 0.1.0"
+          echo "Next version would be: 0.1.1"
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+          echo "version=0.1.1" >> "$GITHUB_OUTPUT"
+
+  release:
+    needs: check-release
+    if: ${{ needs.check-release.outputs.should_release == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Mock release process
+        run: |
+          echo "Creating release version ${{ needs.check-release.outputs.version }}"
+          echo "Updating CHANGELOG.md"
+          echo "Creating git tag"
+
+      - name: Mock GitHub Release creation
+        run: |
+          echo "Creating GitHub Release v${{ needs.check-release.outputs.version }}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tower-http = { version = "0.5", features = ["full"] }
 # Schema Validation
 jsonschema = "0.17"
 schemars = { version = "0.8", features = ["derive"] }
+semver = "1.0"
 
 # Git Integration
 git2 = { version = "0.18", features = ["vendored-openssl"] }
@@ -53,6 +54,7 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+clap = { version = "4.5.4", features = ["derive"] }
 
 # Testing
 tokio-test = "0.4"
@@ -68,9 +70,11 @@ serde_yaml = { workspace = true }
 serde_json = { workspace = true }
 jsonschema = { workspace = true }
 schemars = { workspace = true }
+semver = { workspace = true }
 git2 = { workspace = true }
 chrono = { workspace = true }
 time = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 tempfile = { workspace = true }
+clap = { workspace = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::error::Error;
+use std::error::Error as StdError;
 use std::fmt;
 
 #[derive(Debug)]
@@ -11,6 +11,14 @@ pub enum AureaCoreError {
     Config(String),
     /// Error during service operations
     Service(String),
+    /// Error during schema validation
+    ValidationError(String),
+    /// Error during schema compilation
+    SchemaCompilationError(String),
+    /// Incompatible schema version
+    IncompatibleVersion(String),
+    /// Feature not implemented
+    NotImplemented(String),
     // We'll add more error types as we implement more features
 }
 
@@ -21,12 +29,18 @@ impl fmt::Display for AureaCoreError {
             AureaCoreError::Io(err) => write!(f, "IO error: {}", err),
             AureaCoreError::Config(msg) => write!(f, "Configuration error: {}", msg),
             AureaCoreError::Service(msg) => write!(f, "Service error: {}", msg),
+            AureaCoreError::ValidationError(msg) => write!(f, "Validation error: {}", msg),
+            AureaCoreError::SchemaCompilationError(msg) => {
+                write!(f, "Schema compilation error: {}", msg)
+            }
+            AureaCoreError::IncompatibleVersion(msg) => write!(f, "Incompatible version: {}", msg),
+            AureaCoreError::NotImplemented(msg) => write!(f, "Not implemented: {}", msg),
         }
     }
 }
 
-impl Error for AureaCoreError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
+impl StdError for AureaCoreError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
             AureaCoreError::Io(err) => Some(err),
             _ => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,8 @@ pub mod registry;
 pub mod schema;
 
 pub use error::{AureaCoreError, Result};
-pub use registry::{Service, ServiceConfig, ServiceRegistry, ServiceStatus};
+pub use registry::{
+    Service, ServiceConfig, ServiceRegistry, ServiceState, ServiceStatus, ValidationSummary,
+};
+pub use schema::service::{Dependency, Endpoint, ServiceSchema, ServiceType};
+pub use schema::validation::{CompiledSchema, SchemaType, ValidationService, VersionCompatibility};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,159 @@
 //! AureaCore service catalog
 
-use tracing::info;
+use std::path::PathBuf;
+use std::process;
+
+use aureacore::{ServiceRegistry, ValidationSummary};
+use clap::{Parser, Subcommand};
+use tracing::{error, info};
+
+/// Command-line arguments
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    /// Repository URL
+    #[arg(short, long, default_value = "")]
+    repository: String,
+
+    /// Git branch
+    #[arg(short, long, default_value = "main")]
+    branch: String,
+
+    /// Working directory for configuration files
+    #[arg(short, long, default_value = "./config")]
+    work_dir: PathBuf,
+
+    /// Subcommand to execute
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+/// Subcommands
+#[derive(Subcommand)]
+enum Commands {
+    /// Initialize the service catalog
+    Init,
+
+    /// Update the service catalog
+    Update,
+
+    /// Validate all services
+    Validate,
+
+    /// Register a new service
+    Register {
+        /// Service name
+        #[arg(short, long)]
+        name: String,
+
+        /// Path to the service configuration file
+        #[arg(short, long)]
+        config: PathBuf,
+    },
+}
+
+/// Initialize the service registry
+fn init_registry(cli: &Cli) -> aureacore::Result<ServiceRegistry> {
+    // Use environment variables if repository URL is not provided
+    let repo_url = if cli.repository.is_empty() {
+        std::env::var("AUREACORE_REPO").unwrap_or_else(|_| {
+            error!("Repository URL not provided. Use --repository or AUREACORE_REPO env var.");
+            process::exit(1);
+        })
+    } else {
+        cli.repository.clone()
+    };
+
+    let work_dir = cli.work_dir.clone();
+    if !work_dir.exists() {
+        std::fs::create_dir_all(&work_dir).map_err(|e| {
+            error!("Failed to create work directory: {}", e);
+            aureacore::AureaCoreError::Io(e)
+        })?;
+    }
+
+    ServiceRegistry::new(repo_url, cli.branch.clone(), work_dir)
+}
+
+/// Display validation summary
+fn display_validation_summary(summary: &ValidationSummary) {
+    println!("Validation Summary:");
+    println!("------------------");
+    println!("Total services: {}", summary.total_count());
+    println!("Successful: {}", summary.successful_count());
+    println!("Failed: {}", summary.failed_count());
+
+    if !summary.successful.is_empty() {
+        println!("\nSuccessful services:");
+        for service in &summary.successful {
+            println!("  ✅ {}", service);
+        }
+    }
+
+    if !summary.failed.is_empty() {
+        println!("\nFailed services:");
+        for (service, error) in &summary.failed {
+            println!("  ❌ {}: {}", service, error);
+        }
+    }
+}
 
 #[tokio::main]
-async fn main() {
+async fn main() -> aureacore::Result<()> {
     // Initialize logging
     tracing_subscriber::fmt::init();
 
     info!("Starting AureaCore service catalog...");
+
+    // Parse command-line arguments
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Some(Commands::Init) => {
+            info!("Initializing service catalog...");
+            let mut registry = init_registry(&cli)?;
+            registry.init()?;
+            info!("Service catalog initialized successfully");
+        }
+        Some(Commands::Update) => {
+            info!("Updating service catalog...");
+            let mut registry = init_registry(&cli)?;
+            registry.update()?;
+            registry.load_services()?;
+            info!("Service catalog updated successfully");
+        }
+        Some(Commands::Validate) => {
+            info!("Validating all services...");
+            let mut registry = init_registry(&cli)?;
+            registry.load_services()?;
+
+            let summary = registry.validate_all_services()?;
+            display_validation_summary(&summary);
+
+            if summary.failed_count() > 0 {
+                process::exit(1);
+            }
+        }
+        Some(Commands::Register { name, config }) => {
+            info!("Registering service {}...", name);
+            let mut registry = init_registry(&cli)?;
+
+            // Read config file
+            let config_content = std::fs::read_to_string(config).map_err(|e| {
+                error!("Failed to read config file: {}", e);
+                aureacore::AureaCoreError::Io(e)
+            })?;
+
+            // Register service
+            registry.register_service(name, &config_content)?;
+            info!("Service {} registered successfully", name);
+        }
+        None => {
+            info!("No command specified, use --help for available commands");
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -15,7 +161,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_main() {
-        main();
+    fn test_display_validation_summary() {
+        let mut summary = ValidationSummary::new();
+        summary.successful.push("service1".to_string());
+        summary.successful.push("service2".to_string());
+        summary.failed.push(("service3".to_string(), "error".to_string()));
+
+        display_validation_summary(&summary);
     }
 }

--- a/src/registry/service.rs
+++ b/src/registry/service.rs
@@ -1,9 +1,12 @@
-use std::fmt;
+use std::path::Path;
+use std::{fmt, fs};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json;
 
-use crate::error::Result;
+use crate::error::{AureaCoreError, Result};
+use crate::schema::validation::ValidationService;
 
 /// Configuration for a service
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -18,7 +21,7 @@ pub struct ServiceConfig {
 }
 
 fn default_schema_version() -> String {
-    "1.0".to_string()
+    "1.0.0".to_string()
 }
 
 /// Status of a service
@@ -90,13 +93,21 @@ pub struct Service {
     pub status: ServiceStatus,
     /// When the service was last updated
     pub last_updated: DateTime<Utc>,
+    /// Cached service schema data
+    pub schema_data: Option<serde_json::Value>,
 }
 
 impl Service {
     /// Creates a new service instance
     pub fn new(name: String, config: ServiceConfig) -> Self {
         let now = Utc::now();
-        Self { name, config, status: ServiceStatus::new(ServiceState::Inactive), last_updated: now }
+        Self {
+            name,
+            config,
+            status: ServiceStatus::new(ServiceState::Inactive),
+            last_updated: now,
+            schema_data: None,
+        }
     }
 
     /// Updates the service configuration
@@ -104,14 +115,82 @@ impl Service {
         self.config = config;
         self.last_updated = Utc::now();
         self.status = ServiceStatus::new(ServiceState::Validating);
+        self.schema_data = None;
         Ok(())
     }
 
+    /// Loads the service schema data from the config path
+    fn load_schema_data(&mut self) -> Result<&serde_json::Value> {
+        if self.schema_data.is_none() {
+            let config_path = Path::new(&self.config.config_path);
+
+            if !config_path.exists() {
+                return Err(AureaCoreError::Service(format!(
+                    "Configuration file not found: {}",
+                    self.config.config_path
+                )));
+            }
+
+            let config_content = fs::read_to_string(config_path).map_err(|e| {
+                AureaCoreError::Service(format!("Failed to read configuration file: {}", e))
+            })?;
+
+            // Parse the configuration content based on file extension
+            let data = if config_path.extension().is_some_and(|ext| ext == "json") {
+                serde_json::from_str::<serde_json::Value>(&config_content).map_err(|e| {
+                    AureaCoreError::Service(format!("Failed to parse JSON configuration: {}", e))
+                })?
+            } else if config_path.extension().is_some_and(|ext| ext == "yaml" || ext == "yml") {
+                let yaml_value: serde_yaml::Value =
+                    serde_yaml::from_str(&config_content).map_err(|e| {
+                        AureaCoreError::Service(format!(
+                            "Failed to parse YAML configuration: {}",
+                            e
+                        ))
+                    })?;
+
+                // Convert YAML to JSON value
+                serde_json::to_value(yaml_value).map_err(|e| {
+                    AureaCoreError::Service(format!("Failed to convert YAML to JSON: {}", e))
+                })?
+            } else {
+                return Err(AureaCoreError::Service(format!(
+                    "Unsupported configuration file format: {}",
+                    self.config.config_path
+                )));
+            };
+
+            self.schema_data = Some(data);
+        }
+
+        Ok(self.schema_data.as_ref().unwrap())
+    }
+
+    // Mock the load_schema_data method for testing
+    #[cfg(test)]
+    fn mock_schema_data(&mut self, schema_data: serde_json::Value) {
+        self.schema_data = Some(schema_data);
+    }
+
     /// Validates the service configuration
-    pub fn validate(&mut self) -> Result<()> {
-        // TODO: Implement schema validation
-        self.status = ServiceStatus::new(ServiceState::Active);
-        Ok(())
+    pub fn validate(&mut self, validation_service: &mut ValidationService) -> Result<()> {
+        self.status = ServiceStatus::new(ServiceState::Validating);
+
+        // Load the schema data
+        let schema_data = self.load_schema_data()?;
+
+        // Validate the schema
+        match validation_service.validate_service(schema_data) {
+            Ok(_) => {
+                self.status = ServiceStatus::new(ServiceState::Active);
+                Ok(())
+            }
+            Err(err) => {
+                let error_message = format!("Schema validation failed: {}", err);
+                self.status = ServiceStatus::new(ServiceState::Error).with_error(error_message);
+                Err(err)
+            }
+        }
     }
 
     /// Gets the current service status
@@ -127,19 +206,22 @@ impl Service {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use serde_json::json;
 
-    fn create_test_config() -> ServiceConfig {
+    use super::*;
+    use crate::schema::validation::ValidationService;
+
+    fn create_test_config(config_path: &str) -> ServiceConfig {
         ServiceConfig {
             namespace: Some("test".to_string()),
-            config_path: "test/config.yaml".to_string(),
-            schema_version: "1.0".to_string(),
+            config_path: config_path.to_string(),
+            schema_version: "1.0.0".to_string(),
         }
     }
 
     #[test]
     fn test_service_creation() {
-        let config = create_test_config();
+        let config = create_test_config("test/config.yaml");
         let service = Service::new("test-service".to_string(), config);
         assert_eq!(service.name, "test-service");
         assert_eq!(service.status.state, ServiceState::Inactive);
@@ -147,43 +229,24 @@ mod tests {
 
     #[test]
     fn test_service_update_config() {
-        let config = create_test_config();
+        let config = create_test_config("test/config.yaml");
         let mut service = Service::new("test-service".to_string(), config);
 
         let new_config = ServiceConfig {
             namespace: Some("new-test".to_string()),
             config_path: "new-test/config.yaml".to_string(),
-            schema_version: "1.1".to_string(),
+            schema_version: "1.1.0".to_string(),
         };
         service.update_config(new_config.clone()).unwrap();
         assert_eq!(service.config.namespace, Some("new-test".to_string()));
         assert_eq!(service.config.config_path, "new-test/config.yaml");
+        assert_eq!(service.config.schema_version, "1.1.0");
         assert_eq!(service.status.state, ServiceState::Validating);
     }
 
     #[test]
-    fn test_service_status_transitions() {
-        let config = create_test_config();
-        let mut service = Service::new("test-service".to_string(), config);
-
-        // Initial state
-        assert_eq!(service.status.state, ServiceState::Inactive);
-        assert!(service.status.error_message.is_none());
-
-        // Set error
-        service.set_error("test error".to_string());
-        assert_eq!(service.status.state, ServiceState::Error);
-        assert_eq!(service.status.error_message, Some("test error".to_string()));
-
-        // Validate (moves to Active)
-        service.validate().unwrap();
-        assert_eq!(service.status.state, ServiceState::Active);
-        assert!(service.status.error_message.is_none());
-    }
-
-    #[test]
     fn test_service_timestamps() {
-        let config = create_test_config();
+        let config = create_test_config("test/config.yaml");
         let mut service = Service::new("test-service".to_string(), config);
 
         let initial_update = service.last_updated;
@@ -193,10 +256,58 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(5));
 
         // Update should change both timestamps
-        let new_config = create_test_config();
+        let new_config = create_test_config("test/config.yaml");
         service.update_config(new_config).unwrap();
 
         assert!(service.last_updated > initial_update);
         assert!(service.status.last_checked > initial_check);
+    }
+
+    #[test]
+    fn test_service_validation() {
+        let config = create_test_config("test/config.json");
+        let mut service = Service::new("test-service".to_string(), config);
+        let mut validation_service = ValidationService::new();
+
+        // Mock the schema data to avoid file system access
+        service.mock_schema_data(json!({
+            "name": "test-service",
+            "version": "1.0.0",
+            "service_type": {
+                "type": "rest"
+            },
+            "endpoints": [
+                {
+                    "name": "test",
+                    "path": "/test"
+                }
+            ],
+            "schema_version": "1.0.0"
+        }));
+
+        // Validation should pass for valid schema
+        let result = service.validate(&mut validation_service);
+        assert!(result.is_ok(), "Validation failed: {:?}", result);
+        assert_eq!(service.status.state, ServiceState::Active);
+    }
+
+    #[test]
+    fn test_service_validation_failure() {
+        let config = create_test_config("test/config.json");
+        let mut service = Service::new("test-service".to_string(), config);
+        let mut validation_service = ValidationService::new();
+
+        // Mock the schema data with invalid data
+        service.mock_schema_data(json!({
+            "name": "test-service",
+            "version": "1.0.0"
+            // Missing required fields
+        }));
+
+        // Validation should fail for invalid schema
+        let result = service.validate(&mut validation_service);
+        assert!(result.is_err());
+        assert_eq!(service.status.state, ServiceState::Error);
+        assert!(service.status.error_message.is_some());
     }
 }

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,4 +1,7 @@
 pub mod root;
 pub mod service;
+pub mod validation;
 
 pub use root::{GlobalConfig, RootConfig, ServiceRef};
+pub use service::{Dependency, Endpoint, ServiceSchema, ServiceType};
+pub use validation::{CompiledSchema, SchemaType, ValidationService, VersionCompatibility};

--- a/src/schema/service.rs
+++ b/src/schema/service.rs
@@ -1,1 +1,191 @@
+use std::collections::HashMap;
 
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Schema for a service configuration
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ServiceSchema {
+    /// Name of the service
+    pub name: String,
+    /// Version of the service
+    pub version: String,
+    /// Description of the service
+    pub description: Option<String>,
+    /// Owner of the service
+    pub owner: Option<String>,
+    /// Documentation URL for the service
+    pub documentation_url: Option<String>,
+    /// Service type
+    pub service_type: ServiceType,
+    /// Service endpoints
+    pub endpoints: Vec<Endpoint>,
+    /// Dependencies on other services
+    pub dependencies: Option<Vec<Dependency>>,
+    /// Extensible metadata for additional attributes
+    #[serde(default)]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+/// Types of services
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+#[serde(tag = "type", content = "custom_type")]
+pub enum ServiceType {
+    /// HTTP/REST service
+    Rest,
+    /// gRPC service
+    Grpc,
+    /// GraphQL service
+    GraphQL,
+    /// Event-driven service
+    EventDriven,
+    /// Other type of service
+    #[serde(rename = "other")]
+    Other(String),
+}
+
+/// Endpoint definition
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct Endpoint {
+    /// Name of the endpoint
+    pub name: String,
+    /// Path or address of the endpoint
+    pub path: String,
+    /// Method or protocol for the endpoint
+    pub method: Option<String>,
+    /// Documentation about the endpoint
+    pub description: Option<String>,
+}
+
+/// Dependency on another service
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct Dependency {
+    /// Name of the service dependency
+    pub service: String,
+    /// Version constraint for the dependency
+    pub version_constraint: Option<String>,
+    /// Whether this dependency is required
+    #[serde(default = "default_true")]
+    pub required: bool,
+}
+
+/// Default function to set dependency as required by default
+fn default_true() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use jsonschema::JSONSchema;
+    use schemars::schema_for;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_valid_service_schema() {
+        let schema = serde_json::to_value(schema_for!(ServiceSchema)).unwrap();
+        let validator = JSONSchema::compile(&schema).unwrap();
+
+        let config = json!({
+            "name": "auth-service",
+            "version": "1.0.0",
+            "description": "Authentication service",
+            "owner": "Platform Team",
+            "documentation_url": "https://docs.example.com/auth",
+            "service_type": {
+                "type": "rest"
+            },
+            "endpoints": [
+                {
+                    "name": "login",
+                    "path": "/api/v1/login",
+                    "method": "POST",
+                    "description": "User login endpoint"
+                }
+            ],
+            "dependencies": [
+                {
+                    "service": "user-service",
+                    "version_constraint": ">=1.0.0",
+                    "required": true
+                }
+            ],
+            "metadata": {
+                "team_slack_channel": "#auth-team",
+                "priority": 1
+            }
+        });
+
+        let validation = validator.validate(&config);
+        assert!(validation.is_ok(), "Validation failed");
+    }
+
+    #[test]
+    fn test_invalid_service_schema() {
+        let schema = serde_json::to_value(schema_for!(ServiceSchema)).unwrap();
+        let validator = JSONSchema::compile(&schema).unwrap();
+
+        let config = json!({
+            "name": "auth-service",
+            "version": "1.0.0",
+            // Missing required field "service_type"
+            "endpoints": []
+        });
+
+        let validation = validator.validate(&config);
+        assert!(validation.is_err(), "Expected validation to fail");
+    }
+
+    #[test]
+    fn test_service_schema_with_custom_service_type() {
+        let schema = serde_json::to_value(schema_for!(ServiceSchema)).unwrap();
+        let validator = JSONSchema::compile(&schema).unwrap();
+
+        let config = json!({
+            "name": "legacy-service",
+            "version": "1.0.0",
+            "service_type": {
+                "type": "other",
+                "custom_type": "legacy-soap"
+            },
+            "endpoints": [
+                {
+                    "name": "get-data",
+                    "path": "/data"
+                }
+            ]
+        });
+
+        let validation = validator.validate(&config);
+        assert!(validation.is_ok(), "Validation failed");
+    }
+
+    #[test]
+    fn test_service_schema_with_metadata() {
+        let schema = serde_json::to_value(schema_for!(ServiceSchema)).unwrap();
+        let validator = JSONSchema::compile(&schema).unwrap();
+
+        let config = json!({
+            "name": "metrics-service",
+            "version": "1.0.0",
+            "service_type": {
+                "type": "rest"
+            },
+            "endpoints": [],
+            "metadata": {
+                "team": "Platform",
+                "priority": 2,
+                "tags": ["metrics", "monitoring"],
+                "config": {
+                    "retention_days": 30,
+                    "sampling_rate": 0.1
+                }
+            }
+        });
+
+        let validation = validator.validate(&config);
+        assert!(validation.is_ok(), "Validation failed");
+    }
+}

--- a/src/schema/validation.rs
+++ b/src/schema/validation.rs
@@ -1,0 +1,312 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use jsonschema::JSONSchema;
+use schemars::schema_for;
+use semver::Version;
+
+use crate::error::{AureaCoreError as Error, Result};
+use crate::schema::service::ServiceSchema;
+
+/// Current schema version used by the system
+pub const CURRENT_SCHEMA_VERSION: &str = "1.0.0";
+
+/// Type of schema to validate against
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum SchemaType {
+    /// Root configuration schema
+    Root,
+    /// Service configuration schema
+    Service,
+    /// Custom schema with specified name
+    Custom(String),
+}
+
+/// Result of version compatibility check
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum VersionCompatibility {
+    /// Versions are compatible
+    Compatible,
+    /// Minor incompatibility (forward-compatible)
+    MinorIncompatible,
+    /// Major incompatibility (breaking changes)
+    MajorIncompatible,
+}
+
+/// Checks compatibility between versions (standalone function)
+pub fn check_version_compatibility(version: &str, current: &str) -> VersionCompatibility {
+    // Parse versions
+    let v1 = match Version::parse(version) {
+        Ok(v) => v,
+        Err(_) => return VersionCompatibility::MajorIncompatible,
+    };
+
+    let v2 = match Version::parse(current) {
+        Ok(v) => v,
+        Err(_) => return VersionCompatibility::MajorIncompatible,
+    };
+
+    // Compare major and minor versions
+    if v1.major != v2.major {
+        VersionCompatibility::MajorIncompatible
+    } else if v1.minor != v2.minor {
+        VersionCompatibility::MinorIncompatible
+    } else {
+        VersionCompatibility::Compatible
+    }
+}
+
+/// A compiled JSON schema validator
+#[derive(Clone)]
+pub struct CompiledSchema {
+    schema: Arc<JSONSchema>,
+}
+
+impl CompiledSchema {
+    /// Creates a new compiled schema
+    pub fn new(schema: JSONSchema) -> Self {
+        Self { schema: Arc::new(schema) }
+    }
+
+    /// Validates a value against the schema
+    pub fn validate(&self, value: &serde_json::Value) -> std::result::Result<(), Vec<String>> {
+        match self.schema.validate(value) {
+            Ok(_) => Ok(()),
+            Err(errors) => {
+                let error_strings: Vec<String> = errors.map(|err| format!("{}", err)).collect();
+                Err(error_strings)
+            }
+        }
+    }
+}
+
+/// Service for validating configuration against schemas
+pub struct ValidationService {
+    schema_cache: HashMap<SchemaType, CompiledSchema>,
+}
+
+impl Default for ValidationService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ValidationService {
+    /// Creates a new validation service
+    pub fn new() -> Self {
+        Self { schema_cache: HashMap::new() }
+    }
+
+    /// Gets or compiles a schema of the specified type
+    pub fn get_or_compile_schema(&mut self, schema_type: SchemaType) -> Result<&CompiledSchema> {
+        if !self.schema_cache.contains_key(&schema_type) {
+            let compiled = self.compile_schema(&schema_type)?;
+            self.schema_cache.insert(schema_type.clone(), compiled);
+        }
+
+        Ok(self.schema_cache.get(&schema_type).unwrap())
+    }
+
+    /// Compiles a schema of the specified type
+    pub fn compile_schema(&self, schema_type: &SchemaType) -> Result<CompiledSchema> {
+        let schema_value = match schema_type {
+            SchemaType::Service => {
+                serde_json::to_value(schema_for!(ServiceSchema)).map_err(|e| {
+                    Error::SchemaCompilationError(format!("Failed to generate schema: {}", e))
+                })?
+            }
+            SchemaType::Root => {
+                // Root schema will be implemented later
+                return Err(Error::NotImplemented("Root schema not yet implemented".to_string()));
+            }
+            SchemaType::Custom(name) => {
+                return Err(Error::NotImplemented(format!(
+                    "Custom schema {} not implemented",
+                    name
+                )));
+            }
+        };
+
+        let schema = JSONSchema::compile(&schema_value).map_err(|e| {
+            Error::SchemaCompilationError(format!("Failed to compile schema: {}", e))
+        })?;
+
+        Ok(CompiledSchema::new(schema))
+    }
+
+    /// Validates a service configuration
+    pub fn validate_service(&mut self, config: &serde_json::Value) -> Result<()> {
+        // Get the service schema
+        let schema = self.get_or_compile_schema(SchemaType::Service)?;
+
+        // Extract version from config for compatibility check
+        let config_version =
+            config.get("schema_version").and_then(|v| v.as_str()).unwrap_or("1.0.0");
+
+        // Check using the standalone function
+        let compatibility = check_version_compatibility(config_version, CURRENT_SCHEMA_VERSION);
+
+        match compatibility {
+            VersionCompatibility::Compatible => {
+                // Perform validation
+                match schema.validate(config) {
+                    Ok(_) => Ok(()),
+                    Err(errors) => Err(Error::ValidationError(format!(
+                        "Schema validation failed: {}",
+                        errors.join(", ")
+                    ))),
+                }
+            }
+            VersionCompatibility::MinorIncompatible => {
+                // Log warning but continue with validation
+                tracing::warn!(
+                    "Minor schema version incompatibility: config version {} vs current {}",
+                    config_version,
+                    CURRENT_SCHEMA_VERSION
+                );
+
+                match schema.validate(config) {
+                    Ok(_) => Ok(()),
+                    Err(errors) => Err(Error::ValidationError(format!(
+                        "Schema validation failed: {}",
+                        errors.join(", ")
+                    ))),
+                }
+            }
+            VersionCompatibility::MajorIncompatible => Err(Error::IncompatibleVersion(format!(
+                "Schema version {} is incompatible with current version {}",
+                config_version, CURRENT_SCHEMA_VERSION
+            ))),
+        }
+    }
+
+    /// Checks compatibility between versions
+    pub fn check_version_compatibility(
+        &self,
+        version: &str,
+        current: &str,
+    ) -> VersionCompatibility {
+        // Parse versions
+        let v1 = match Version::parse(version) {
+            Ok(v) => v,
+            Err(_) => return VersionCompatibility::MajorIncompatible,
+        };
+
+        let v2 = match Version::parse(current) {
+            Ok(v) => v,
+            Err(_) => return VersionCompatibility::MajorIncompatible,
+        };
+
+        // Compare major and minor versions
+        if v1.major != v2.major {
+            VersionCompatibility::MajorIncompatible
+        } else if v1.minor != v2.minor {
+            VersionCompatibility::MinorIncompatible
+        } else {
+            VersionCompatibility::Compatible
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_version_compatibility() {
+        let service = ValidationService::new();
+
+        // Compatible versions
+        assert_eq!(
+            service.check_version_compatibility("1.0.0", "1.0.1"),
+            VersionCompatibility::Compatible
+        );
+
+        // Minor incompatible
+        assert_eq!(
+            service.check_version_compatibility("1.0.0", "1.1.0"),
+            VersionCompatibility::MinorIncompatible
+        );
+
+        // Major incompatible
+        assert_eq!(
+            service.check_version_compatibility("1.0.0", "2.0.0"),
+            VersionCompatibility::MajorIncompatible
+        );
+
+        // Invalid version
+        assert_eq!(
+            service.check_version_compatibility("invalid", "1.0.0"),
+            VersionCompatibility::MajorIncompatible
+        );
+    }
+
+    #[test]
+    fn test_schema_compilation() {
+        let mut service = ValidationService::new();
+
+        // Service schema should compile successfully
+        let schema_result = service.get_or_compile_schema(SchemaType::Service);
+        assert!(schema_result.is_ok());
+    }
+
+    #[test]
+    fn test_service_validation_success() {
+        let mut service = ValidationService::new();
+
+        let config = json!({
+            "name": "test-service",
+            "version": "1.0.0",
+            "service_type": {
+                "type": "rest"
+            },
+            "endpoints": [
+                {
+                    "name": "test",
+                    "path": "/test"
+                }
+            ],
+            "schema_version": "1.0.0"
+        });
+
+        let result = service.validate_service(&config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_service_validation_failure() {
+        let mut service = ValidationService::new();
+
+        // Missing required fields
+        let config = json!({
+            "name": "test-service",
+            "version": "1.0.0"
+            // Missing service_type and endpoints
+        });
+
+        let result = service.validate_service(&config);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(Error::ValidationError(_))));
+    }
+
+    #[test]
+    fn test_service_validation_incompatible_version() {
+        let mut service = ValidationService::new();
+
+        let config = json!({
+            "name": "test-service",
+            "version": "1.0.0",
+            "service_type": {
+                "type": "rest"
+            },
+            "endpoints": [],
+            "schema_version": "2.0.0" // Major version incompatibility
+        });
+
+        let result = service.validate_service(&config);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(Error::IncompatibleVersion(_))));
+    }
+}


### PR DESCRIPTION
# Service Schema Validation

Implements the Service Schema Validation feature as described in the design document.

## Changes

- Added ServiceSchema, ServiceType, Endpoint, and Dependency structs
- Implemented ValidationService with schema compilation and validation
- Added version compatibility checking
- Implemented flexible schema validation for different service types
- Added extensible metadata support via HashMap
- Integrated validation with the ServiceRegistry
- Added comprehensive tests for all functionality

## Testing

All tests are passing as shown in the pre-push checks above. The implementation follows the design document created in the wiki.
