### PR TITLE
fix(ci): use valid GitHub Actions bot email for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,8 @@ jobs:
       
       - name: Set up Git user
         run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
# Fix Release Attribution

Updates GitHub Actions configuration to properly attribute releases in the GitHub UI.

## Changes

- Changed Git user configuration in the release workflow to use the official GitHub Actions bot email
- Updated from `actions@github.com` to `41898282+github-actions[bot]@users.noreply.github.com`
- Changed user name from "GitHub Actions" to "github-actions[bot]"

## Problem Solved

Currently, releases created by our workflow show as "@invalid-email-address" in the GitHub UI rather than properly attributing them to GitHub Actions. This change ensures releases will be properly attributed to the GitHub Actions bot, making our release history cleaner and more professional.

## Impact

This is a non-functional change that only affects how releases appear in the GitHub UI. No functional changes to the release process itself.