### PR TITLE
feat(schema): implement service schema validation with dependency checks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,11 +82,20 @@ fn display_validation_summary(summary: &ValidationSummary) {
     println!("Total services: {}", summary.total_count());
     println!("Successful: {}", summary.successful_count());
     println!("Failed: {}", summary.failed_count());
+    println!("Warnings: {}", summary.warning_count());
+    println!("Timestamp: {}", summary.timestamp.format("%Y-%m-%d %H:%M:%S UTC"));
 
     if !summary.successful.is_empty() {
         println!("\nSuccessful services:");
         for service in &summary.successful {
             println!("  ✅ {}", service);
+        }
+    }
+
+    if !summary.warnings.is_empty() {
+        println!("\nWarnings:");
+        for (service, warning) in &summary.warnings {
+            println!("  ⚠️  {}: {}", service, warning);
         }
     }
 

--- a/src/registry/service.rs
+++ b/src/registry/service.rs
@@ -120,7 +120,7 @@ impl Service {
     }
 
     /// Loads the service schema data from the config path
-    fn load_schema_data(&mut self) -> Result<&serde_json::Value> {
+    pub fn load_schema_data(&mut self) -> Result<&serde_json::Value> {
         if self.schema_data.is_none() {
             let config_path = Path::new(&self.config.config_path);
 


### PR DESCRIPTION
# Service Schema Validation

This PR implements the Service Schema Validation feature as designed in the [Service Schema Validation](https://github.com/spiralhouse/aureacore/wiki/Service-Schema-Validation) design document.

## Changes

- Added `ServiceSchema` struct with support for flexible service types and metadata
- Implemented validation service with schema compilation and caching
- Added version compatibility checking for graceful schema evolution
- Implemented dependency validation to detect missing service dependencies
- Enhanced validation summary to include warnings about missing dependencies
- Updated test suite with comprehensive tests for schema validation
- Fixed field names in dependency validation to use "service" instead of "name"
