### PR TITLE
fix: handle dependabot PRs in codecov workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,17 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
+        if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.lcov
           fail_ci_if_error: true
+          verbose: true
+          
+      - name: Upload coverage to Codecov (Dependabot)
+        uses: codecov/codecov-action@v5
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        with:
+          files: coverage.lcov
+          fail_ci_if_error: false
           verbose: true 


### PR DESCRIPTION
## Overview

This PR fixes the CI failures for dependabot pull requests by modifying the GitHub Actions workflow to handle Codecov reporting differently for dependabot PRs.

## Problem

Dependabot pull requests can't access the `CODECOV_TOKEN` secret due to GitHub's security restrictions for automated processes. This causes the Codecov upload step to fail with:

```
error - 2025-03-31 21:06:36,107 -- Upload failed: {"message":"Token required because branch is protected"}
```

## Solution

This PR adds conditional steps in the workflow:

1. For regular PRs, continue using the `CODECOV_TOKEN` as before
2. For dependabot PRs, skip token validation and set `fail_ci_if_error: false` to prevent build failures

This approach ensures:
- Regular PRs maintain strict coverage validation
- Dependabot PRs can still upload coverage data when possible, but don't fail the build when token access is restricted
- The CI process can complete successfully for dependabot updates